### PR TITLE
problem with rabbit_virtualhost

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,7 +26,7 @@
 #    user to connect to the rabbit server. Optional. Defaults to 'guest'
 #  [*rabbit_password*]
 #    password to connect to the rabbit_server. Optional. Defaults to empty.
-#  [*rabbit_virtualhost*]
+#  [*rabbit_virtual_host*]
 #    virtualhost to use. Optional. Defaults to '/'
 #
 # [*qpid_hostname*]
@@ -56,7 +56,7 @@ class ceilometer(
   $rabbit_hosts       = undef,
   $rabbit_userid      = 'guest',
   $rabbit_password    = '',
-  $rabbit_virtualhost = '/',
+  $rabbit_virtual_host = '/',
   $qpid_hostname = 'localhost',
   $qpid_port = 5672,
   $qpid_username = 'guest',
@@ -139,7 +139,7 @@ class ceilometer(
       ceilometer_config {
         'DEFAULT/rabbit_userid'          : value => $rabbit_userid;
         'DEFAULT/rabbit_password'        : value => $rabbit_password;
-        'DEFAULT/rabbit_virtualhost'     : value => $rabbit_virtualhost;
+        'DEFAULT/rabbit_virtual_host'     : value => $rabbit_virtual_host;
       }
   }
 

--- a/spec/classes/ceilometer_init_spec.rb
+++ b/spec/classes/ceilometer_init_spec.rb
@@ -136,7 +136,7 @@ describe 'ceilometer' do
     it 'configures rabbit' do
       should contain_ceilometer_config('DEFAULT/rabbit_userid').with_value( params[:rabbit_userid] )
       should contain_ceilometer_config('DEFAULT/rabbit_password').with_value( params[:rabbit_password] )
-      should contain_ceilometer_config('DEFAULT/rabbit_virtualhost').with_value( params[:rabbit_virtualhost] )
+      should contain_ceilometer_config('DEFAULT/rabbit_virtual_host').with_value( params[:rabbit_virtual_host] )
     end
 
     it { should contain_ceilometer_config('DEFAULT/rabbit_host').with_value( params[:rabbit_host] ) }
@@ -150,7 +150,7 @@ describe 'ceilometer' do
     it 'configures rabbit' do
       should contain_ceilometer_config('DEFAULT/rabbit_userid').with_value( params[:rabbit_userid] )
       should contain_ceilometer_config('DEFAULT/rabbit_password').with_value( params[:rabbit_password] )
-      should contain_ceilometer_config('DEFAULT/rabbit_virtualhost').with_value( params[:rabbit_virtualhost] )
+      should contain_ceilometer_config('DEFAULT/rabbit_virtual_host').with_value( params[:rabbit_virtual_host] )
     end
 
     it { should contain_ceilometer_config('DEFAULT/rabbit_host').with_ensure('absent') }
@@ -164,7 +164,7 @@ describe 'ceilometer' do
     it 'configures rabbit' do
       should contain_ceilometer_config('DEFAULT/rabbit_userid').with_value( params[:rabbit_userid] )
       should contain_ceilometer_config('DEFAULT/rabbit_password').with_value( params[:rabbit_password] )
-      should contain_ceilometer_config('DEFAULT/rabbit_virtualhost').with_value( params[:rabbit_virtualhost] )
+      should contain_ceilometer_config('DEFAULT/rabbit_virtual_host').with_value( params[:rabbit_virtual_host] )
     end
 
     it { should contain_ceilometer_config('DEFAULT/rabbit_host').with_ensure('absent') }


### PR DESCRIPTION
rabbit_virtualhost is not known in ceilometer grizzly/havana, use rabbit_virtual_host instead.
