### PR TITLE
Don't print sensitive information to stdout

### DIFF
--- a/lib/puppet/type/ceilometer_config.rb
+++ b/lib/puppet/type/ceilometer_config.rb
@@ -10,7 +10,6 @@ Puppet::Type.newtype(:ceilometer_config) do
   newproperty(:value, :array_matching => :all) do
     desc 'The value of the setting to be defined.'
     def insync?(is)
-      puts is
       return true if @should.empty?
       return false unless is.is_a? Array
       return false unless is.length == @should.length


### PR DESCRIPTION
the module is printing sensitive information (like passwords).

Maybe someone forgot to remove this during debug?

 Fabian
